### PR TITLE
use plugin.stop to return from run

### DIFF
--- a/lib/logstash/inputs/heartbeat.rb
+++ b/lib/logstash/inputs/heartbeat.rb
@@ -45,13 +45,14 @@ class LogStash::Inputs::Heartbeat < LogStash::Inputs::Threadable
 
   def run(queue)
     sequence = 0
+    @thread = Thread.current
 
     Stud.interval(@interval) do
       sequence += 1
       event = generate_message(sequence)
       decorate(event)
       queue << event
-      break if sequence == @count
+      break if sequence == @count || stop?
     end # loop
 
   end # def run
@@ -67,4 +68,7 @@ class LogStash::Inputs::Heartbeat < LogStash::Inputs::Threadable
     end
   end
 
+  def stop
+    Stud.stop!(@thread)
+  end
 end # class LogStash::Inputs::Heartbeat


### PR DESCRIPTION
Implements `stop` to return from `run` according to https://github.com/elastic/logstash/issues/3210

Depends on https://github.com/elastic/logstash-devutils/pull/32 and https://github.com/elastic/logstash/pull/3812

This implementation still has a problem that, during the hearbeat sleep, there is no way to abort the plugin `run` method. Therefore a very big `interval_time` can make this plugin hang the shutdown sequence
Maybe an option is to decide to do a Thread.kill if the thread is sleeping?

resolves #8 