### PR TITLE
Populate '[event][sequence]' instead of 'clock' if ECS is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.1.0
-  - Added new `sequence` field to manage the type of sequence generator and added ECS 
+  - Added new `sequence` setting to manage the type of sequence generator and added ECS 
     compatibility behavior [#18](https://github.com/logstash-plugins/logstash-input-heartbeat/pull/18)
 
 ## 3.0.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0
+  - Added new `sequence` field to manage the type of sequence generator and added ECS 
+    compatibility behavior [#18](https://github.com/logstash-plugins/logstash-input-heartbeat/pull/18)
+
 ## 3.0.7
   - Fixed shutdown concurrency issues by simplifying shutdown signal handling [#15](https://github.com/logstash-plugins/logstash-input-heartbeat/pull/15)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -77,7 +77,8 @@ This is typically used only for testing purposes.
 ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
 ** Otherwise, the default value is `disabled`.
 
-Refer to <<plugins-{type}s-{plugin}-ecs,ECS mapping>> for detailed information.
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)]. 
+Refer to <<plugins-{type}s-{plugin}-ecs>> in this topic for detailed information.
 
 [id="plugins-{type}s-{plugin}-interval"]
 ===== `interval` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -29,9 +29,9 @@ availability of Logstash.
 [id="plugins-{type}s-{plugin}-ecs"]
 ==== Elastic Common Schema (ECS)
 
-This plugin could provide a field originally named `clock` to track `epoch` or `sequence` incremental numbers. When
+This plugin could provide a field, originally named `clock`, to track `epoch` or `sequence` incremental numbers. When
 <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>> is enabled that value is now present in the
-`[event][sequence]` subfield.
+event's `[event][sequence]` subfield.
 When <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>> is enabled the use of `message` as
 selector of sequence type is not available and only <<plugins-{type}s-{plugin}-sequence>> is considered. In this
 case if `message` contains sequence selector strings it's ignored.
@@ -71,8 +71,8 @@ This is typically used only for testing purposes.
 
 * Value type is <<string,string>>
 * Supported values are:
-** `disabled`: unstructured connection metadata added at root level
-** `v1`: structured connection metadata added under ECS compliant namespaces
+** `disabled`: `clock` counter field added at root level
+** `v1`: ECS compliant `[event][sequence]` counter field added to the event
 * Default value depends on which version of Logstash is running:
 ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
 ** Otherwise, the default value is `disabled`.
@@ -110,7 +110,7 @@ will output this value into a field called `message`
 
 NOTE: Usage of `epoch`  and `sequence` in `message` setting is deprecated.
 Consider to use <<plugins-{type}s-{plugin}-sequence>> settings, which takes precedence
-over the usage of `message` as selector.
+over the usage of `message setting as selector.
 
 NOTE: If <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>> is enabled
 and `message` contains `epoch` or `sequence` it's ignored and it's not present as a field in
@@ -127,19 +127,17 @@ If you set this to `none` then no sequence field is added.
 
 If you set this to `epoch` then this plugin will use the current
 timestamp in unix timestamp (which is by definition, UTC).  It will
-output this value into a field called `clock`
+output this value into a field called `clock` if <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>>
+is disabled else the field name is `[event][sequence]`.
 
 If you set this to `sequence` then this plugin will send a sequence of
 numbers beginning at 0 and incrementing each interval.  It will
-output this value into a field called `clock`.
+output this value into a field called `clock` if <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>>
+is disabled else the field name is `[event][sequence]`
 
 If `sequence` is defined it takes precedence over `message` configuration; in case `message` doesn't
 have `epoch` or `sequence` values, it will be present also in the generated event together with `clock`
 field.
-
-If <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>> is enabled the `clock` field
-is replaced by `[event][sequence]` subfield.
-
 
 
 [id="plugins-{type}s-{plugin}-threads"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -39,10 +39,10 @@ case if `message` contains sequence selector strings it's ignored.
 
 The existing `host` field is moved to `[host][name]` when ECS is enabled.
 
-.Metadata Location by `ecs_compatibility` value
 [cols="<l,<l,e,<e"]
 |============================================================================================================
 |`disabled`    |`v1`              |Availability                       |Description
+
 |[host]        |[host][name]      |Always                             |Name or address of the host is running the plugin
 |[clock]       |[event][sequence] |When `sequence` setting enables it |Increment counter based on seconds or from local 0 based counter
 |============================================================================================================

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -32,6 +32,7 @@ availability of Logstash.
 This plugin could provide a field, originally named `clock`, to track `epoch` or `sequence` incremental numbers. When
 <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>> is enabled that value is now present in the
 event's `[event][sequence]` subfield.
+
 When <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>> is enabled the use of `message` as
 selector of sequence type is not available and only <<plugins-{type}s-{plugin}-sequence>> is considered. In this
 case if `message` contains sequence selector strings it's ignored.
@@ -98,11 +99,11 @@ The default, `60`, means send a message every 60 seconds.
 
 The message string to use in the event.
 
-If you set this to `epoch` then this plugin will use the current
+If you set this value to `epoch`, then this plugin will use the current
 timestamp in unix timestamp (which is by definition, UTC).  It will
 output this value into a field called `clock`
 
-If you set this to `sequence` then this plugin will send a sequence of
+If you set this value to `sequence`, then this plugin will send a sequence of
 numbers beginning at 0 and incrementing each interval.  It will
 output this value into a field called `clock`
 
@@ -110,11 +111,11 @@ Otherwise, this value will be used verbatim as the event message. It
 will output this value into a field called `message`
 
 NOTE: Usage of `epoch`  and `sequence` in `message` setting is deprecated.
-Consider to use <<plugins-{type}s-{plugin}-sequence>> settings, which takes precedence
-over the usage of `message setting as selector.
+Consider using <<plugins-{type}s-{plugin}-sequence>> settings, which takes precedence
+over the usage of `message` setting as selector.
 
 NOTE: If <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>> is enabled
-and `message` contains `epoch` or `sequence` it's ignored and it's not present as a field in
+and `message` contains `epoch` or `sequence`, it is ignored and is not present as a field in
 the generated event.
 
 
@@ -124,20 +125,20 @@ the generated event.
 * Value can be any of: `none`, `epoch`, `sequence`
 * Default value is `"none""`
 
-If you set this to `none` then no sequence field is added.
+If you set this value to `none`, then no sequence field is added.
 
-If you set this to `epoch` then this plugin will use the current
+If you set this value to `epoch`, then this plugin will use the current
 timestamp in unix timestamp (which is by definition, UTC).  It will
 output this value into a field called `clock` if <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>>
-is disabled else the field name is `[event][sequence]`.
+is disabled. Otherwise, the field name is `[event][sequence]`.
 
-If you set this to `sequence` then this plugin will send a sequence of
+If you set this value to `sequence`, then this plugin will send a sequence of
 numbers beginning at 0 and incrementing each interval.  It will
 output this value into a field called `clock` if <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>>
-is disabled else the field name is `[event][sequence]`
+is disabled. Otherwise, the field name is `[event][sequence]`
 
-If `sequence` is defined it takes precedence over `message` configuration; in case `message` doesn't
-have `epoch` or `sequence` values, it will be present also in the generated event together with `clock`
+If `sequence` is defined, it takes precedence over `message` configuration.
+If `message` doesn't have `epoch` or `sequence` values, it will be present in the generated event together with `clock`
 field.
 
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -26,6 +26,15 @@ Generate heartbeat messages.
 The general intention of this is to test the performance and
 availability of Logstash.
 
+[id="plugins-{type}s-{plugin}-ecs"]
+==== Elastic Common Schema (ECS)
+
+This plugin could provide a field originally named `clock` to track `epoch` or `sequence` incremental numbers. When
+<<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>> is enabled that value is now present in the
+`[event][sequence]` subfield.
+When <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>> is enabled the use of `message` as
+selector of sequence type is not available and only <<plugins-{type}s-{plugin}-sequence>> is considered. In this
+case if `message` contains sequence selector strings it's ignored.
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Heartbeat Input Configuration Options
@@ -36,8 +45,10 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-count>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> | <<string,string>>|No
 | <<plugins-{type}s-{plugin}-interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-message>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-sequence>> |<<string,string>> one of `["none", "epoch", "sequence"]`|No
 | <<plugins-{type}s-{plugin}-threads>> |<<number,number>>|No
 |=======================================================================
 
@@ -54,6 +65,19 @@ input plugins.
 
 How many times to iterate.
 This is typically used only for testing purposes.
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+* Value type is <<string,string>>
+* Supported values are:
+** `disabled`: unstructured connection metadata added at root level
+** `v1`: structured connection metadata added under ECS compliant namespaces
+* Default value depends on which version of Logstash is running:
+** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+** Otherwise, the default value is `disabled`.
+
+Refer to <<plugins-{type}s-{plugin}-ecs,ECS mapping>> for detailed information.
 
 [id="plugins-{type}s-{plugin}-interval"]
 ===== `interval` 
@@ -83,6 +107,40 @@ output this value into a field called `clock`
 
 Otherwise, this value will be used verbatim as the event message. It
 will output this value into a field called `message`
+
+NOTE: Usage of `epoch`  and `sequence` in `message` setting is deprecated.
+Consider to use <<plugins-{type}s-{plugin}-sequence>> settings, which takes precedence
+over the usage of `message` as selector.
+
+NOTE: If <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>> is enabled
+and `message` contains `epoch` or `sequence` it's ignored and it's not present as a field in
+the generated event.
+
+
+[id="plugins-{type}s-{plugin}-sequence"]
+===== `sequence`
+
+* Value can be any of: `none`, `epoch`, `sequence`
+* Default value is `"none""`
+
+If you set this to `none` then no sequence field is added.
+
+If you set this to `epoch` then this plugin will use the current
+timestamp in unix timestamp (which is by definition, UTC).  It will
+output this value into a field called `clock`
+
+If you set this to `sequence` then this plugin will send a sequence of
+numbers beginning at 0 and incrementing each interval.  It will
+output this value into a field called `clock`.
+
+If `sequence` is defined it takes precedence over `message` configuration; in case `message` doesn't
+have `epoch` or `sequence` values, it will be present also in the generated event together with `clock`
+field.
+
+If <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>> is enabled the `clock` field
+is replaced by `[event][sequence]` subfield.
+
+
 
 [id="plugins-{type}s-{plugin}-threads"]
 ===== `threads` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -37,6 +37,16 @@ When <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>> is en
 selector of sequence type is not available and only <<plugins-{type}s-{plugin}-sequence>> is considered. In this
 case if `message` contains sequence selector strings it's ignored.
 
+The existing `host` field is moved to `[host][name]` when ECS is enabled.
+
+.Metadata Location by `ecs_compatibility` value
+[cols="<l,<l,e,<e"]
+|============================================================================================================
+|`disabled`    |`v1`              |Availability                       |Description
+|[host]        |[host][name]      |Always                             |Name or address of the host is running the plugin
+|[clock]       |[event][sequence] |When `sequence` setting enables it |Increment counter based on seconds or from local 0 based counter
+|============================================================================================================
+
 [id="plugins-{type}s-{plugin}-options"]
 ==== Heartbeat Input Configuration Options
 

--- a/lib/logstash/inputs/heartbeat.rb
+++ b/lib/logstash/inputs/heartbeat.rb
@@ -59,7 +59,7 @@ class LogStash::Inputs::Heartbeat < LogStash::Inputs::Threadable
       logger.warn("message contains sequence type specification (epoch|sequence) for this purpose use the sequence option")
     end
     if ecs_compatibility == :disabled
-      unless sequence.nil?
+      if sequence
         @sequence_selector = decode_sequence_selector(sequence)
         logger.debug("Using sequence as sequence selector")
       else

--- a/lib/logstash/inputs/heartbeat.rb
+++ b/lib/logstash/inputs/heartbeat.rb
@@ -72,7 +72,7 @@ class LogStash::Inputs::Heartbeat < LogStash::Inputs::Threadable
         logger.warn("message setting still contains 'epoch' or 'sequence' selectors which is not considered for for configuring the plugin")
       end
     end
-    @valid_message_payload = "epoch" !=  message && "sequence" != message
+    @valid_message_payload = message && "epoch" !=  message && "sequence" != message
   end
 
   def run(queue)

--- a/lib/logstash/inputs/heartbeat.rb
+++ b/lib/logstash/inputs/heartbeat.rb
@@ -3,6 +3,7 @@ require "logstash/inputs/threadable"
 require "logstash/namespace"
 require "stud/interval"
 require "socket" # for Socket.gethostname
+require "logstash/plugin_mixins/deprecation_logger_support"
 require "logstash/plugin_mixins/ecs_compatibility_support"
 
 # Generate heartbeat messages.
@@ -12,6 +13,7 @@ require "logstash/plugin_mixins/ecs_compatibility_support"
 #
 
 class LogStash::Inputs::Heartbeat < LogStash::Inputs::Threadable
+  include LogStash::PluginMixins::DeprecationLoggerSupport
   include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1, :v8 => :v1)
 
   config_name "heartbeat"
@@ -65,7 +67,8 @@ class LogStash::Inputs::Heartbeat < LogStash::Inputs::Threadable
         deprecation_logger.deprecated("magic values of `message` to specify sequence type are deprecated; use separate `sequence` option instead.")
       end
     end
-    @sequence_selector = sequence.to_sym
+    @sequence = "none" if @sequence.nil?
+    @sequence_selector = @sequence.to_sym
   end
 
   def run(queue)

--- a/logstash-input-heartbeat.gemspec
+++ b/logstash-input-heartbeat.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'stud'
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.2'
 
   s.add_development_dependency 'logstash-devutils'
 

--- a/logstash-input-heartbeat.gemspec
+++ b/logstash-input-heartbeat.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'stud'
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.2'
+  s.add_runtime_dependency 'logstash-mixin-deprecation_logger_support', '~>1.0'
 
   s.add_development_dependency 'logstash-devutils'
 

--- a/logstash-input-heartbeat.gemspec
+++ b/logstash-input-heartbeat.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-heartbeat'
-  s.version         = '3.0.7'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Generates heartbeat events for testing"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-heartbeat.gemspec
+++ b/logstash-input-heartbeat.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'stud'
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.2'
   s.add_runtime_dependency 'logstash-mixin-deprecation_logger_support', '~>1.0'
+  s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0'
 
   s.add_development_dependency 'logstash-devutils'
 

--- a/spec/inputs/heartbeat_spec.rb
+++ b/spec/inputs/heartbeat_spec.rb
@@ -43,12 +43,14 @@ describe LogStash::Inputs::Heartbeat do
     it "should return an event with the current time (as epoch)" do
       now = Time.now.to_i
       # Give it a second, just in case
-      expect(subject.generate_message(sequence).get("clock") - now).to be < 2
+      evt = subject.generate_message(sequence)
+      expect(evt.get("clock") - now).to be < 2
+      expect(evt).to_not include "message"
     end # it "should return an event with the current time (as epoch)"
   end # context "Epoch test"
 
   context "Epoch test with ECS enabled" do
-    subject { LogStash::Inputs::Heartbeat.new({"sequence_type" => "epoch", "ecs_compatibility" => :v1}) }
+    subject { LogStash::Inputs::Heartbeat.new({"sequence" => "epoch", "ecs_compatibility" => :v1}) }
 
     it "should return an event with the current time (as epoch)" do
       now = Time.now.to_i
@@ -57,21 +59,21 @@ describe LogStash::Inputs::Heartbeat do
     end
 
     context "and message is defined with sequence selector" do
-      subject { LogStash::Inputs::Heartbeat.new({"sequence_type" => "epoch", "message" => "sequence", "ecs_compatibility" => :v1}) }
+      subject { LogStash::Inputs::Heartbeat.new({"sequence" => "epoch", "message" => "sequence", "ecs_compatibility" => :v1}) }
       
-      it "should return an event without the message field but populating the sequence field as requested by 'sequence_type' setting" do
+      it "should return an event without the message field but populating the sequence field as requested by 'sequence' setting" do
         now = Time.now.to_i
         # Give it a second, just in case
         evt = subject.generate_message(sequence)
         expect(evt.get("[event][sequence]") - now).to be < 2
-        expect(evt.include?("message")).to be false
+        expect(evt).to_not include "message"
       end
     end
 
     context "and message is defined with free text" do
-      subject { LogStash::Inputs::Heartbeat.new({"sequence_type" => "epoch", "message" => "funny message", "ecs_compatibility" => :v1}) }
+      subject { LogStash::Inputs::Heartbeat.new({"sequence" => "epoch", "message" => "funny message", "ecs_compatibility" => :v1}) }
 
-      it "should return an event without the message field but populating the sequence field as requested by 'sequence_type' setting" do
+      it "should return an event without the message field but populating the sequence field as requested by 'sequence' setting" do
         now = Time.now.to_i
         # Give it a second, just in case
         evt = subject.generate_message(sequence)
@@ -95,7 +97,7 @@ describe LogStash::Inputs::Heartbeat do
     end
 
     context "ECS enabled" do
-      subject { LogStash::Inputs::Heartbeat.new("interval" => 1, "sequence_type" => "sequence", "count" => count, "ecs_compatibility" => :v1) }
+      subject { LogStash::Inputs::Heartbeat.new("interval" => 1, "sequence" => "sequence", "count" => count, "ecs_compatibility" => :v1) }
 
       it "should generate a fixed number of events then stop" do
         subject.run(events)
@@ -104,10 +106,10 @@ describe LogStash::Inputs::Heartbeat do
     end
   end
 
-  context "sequence_type settings test" do
-      subject { LogStash::Inputs::Heartbeat.new({"sequence_type" => "epoch", "message" => "sequence", "ecs_compatibility" => :disabled}) }
+  context "sequence settings test" do
+      subject { LogStash::Inputs::Heartbeat.new({"sequence" => "epoch", "message" => "sequence", "ecs_compatibility" => :disabled}) }
 
-      it "should return an event giving sequence_type precedence over message" do
+      it "should return an event giving sequence precedence over message" do
         now = Time.now.to_i
         # Give it a second, just in case
         expect(subject.generate_message(sequence).get("clock") - now).to be < 2

--- a/spec/inputs/heartbeat_spec.rb
+++ b/spec/inputs/heartbeat_spec.rb
@@ -79,4 +79,14 @@ describe LogStash::Inputs::Heartbeat do
       end
     end
   end
+
+  context "sequence_type settings test" do
+      subject { LogStash::Inputs::Heartbeat.new({"sequence_type" => "epoch", "message" => "sequence", "ecs_compatibility" => :disabled}) }
+
+      it "should return an event giving sequence_type precedence over message" do
+        now = Time.now.to_i
+        # Give it a second, just in case
+        expect(subject.generate_message(sequence).get("clock") - now).to be < 2
+      end # it "should return an event with the current time (as epoch)"
+    end # context "Epoch test"
 end

--- a/spec/inputs/heartbeat_spec.rb
+++ b/spec/inputs/heartbeat_spec.rb
@@ -61,12 +61,13 @@ describe LogStash::Inputs::Heartbeat do
     context "and message is defined with sequence selector" do
       subject { LogStash::Inputs::Heartbeat.new({"sequence" => "epoch", "message" => "sequence", "ecs_compatibility" => :v1}) }
       
-      it "should return an event without the message field but populating the sequence field as requested by 'sequence' setting" do
+      it "should return an event with the message field with the exact text provided but populating the sequence field as requested by 'sequence' setting" do
         now = Time.now.to_i
         # Give it a second, just in case
         evt = subject.generate_message(sequence)
         expect(evt.get("[event][sequence]") - now).to be < 2
-        expect(evt).to_not include "message"
+        #expect(evt).to_not include "message"
+        expect(evt.get("message")).to eq("sequence")
       end
     end
 
@@ -107,12 +108,12 @@ describe LogStash::Inputs::Heartbeat do
   end
 
   context "sequence settings test" do
-      subject { LogStash::Inputs::Heartbeat.new({"sequence" => "epoch", "message" => "sequence", "ecs_compatibility" => :disabled}) }
+    subject { LogStash::Inputs::Heartbeat.new({"sequence" => "epoch", "message" => "sequence", "ecs_compatibility" => :disabled}) }
 
-      it "should return an event giving sequence precedence over message" do
-        now = Time.now.to_i
-        # Give it a second, just in case
-        expect(subject.generate_message(sequence).get("clock") - now).to be < 2
-      end # it "should return an event with the current time (as epoch)"
-    end # context "Epoch test"
+    it "should return an event giving sequence precedence over message" do
+      now = Time.now.to_i
+      # Give it a second, just in case
+      expect(subject.generate_message(sequence).get("clock") - now).to be < 2
+    end # it "should return an event with the current time (as epoch)"
+  end # context "Epoch test"
 end


### PR DESCRIPTION
This PR does 3 things:
- enable ECS compatibility, replacing the `clock` field with `[event][sequence]` when ECS is enabled
- introduces a new option named `sequence` to configure the kind of counter used in the "clock/sequence" field
- unrelated to the context of ECS it switches the creation of the Event to the `event_factory` mixin

In non ECS mode the `sequence` setting takes precedence over `message` and if `message` contains a value other then `epoch` or `sequence` it includes also the `message` field in the generated event.

In ECS mode only the `sequence` setting is considered to select the kind of counter, if `message` contains `epoch` or `sequence` its simply ignored and no `message` field is present in the event, otherwise `message` is part of the event together with the `[event][sequence]`

Fixes #17 